### PR TITLE
README's examples with wrong-number-of-arguments error

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ Then add to your Emacs configuration:
 (add-hook 'org-mode-hook
           (lambda ()
             (slash-commands-register-commands
-             '(("todo" . org-insert-todo-heading)
+             '(("todo" . org-insert-todo-heading-respect-content)
                ("link" . org-insert-link)
-               ("src" . org-insert-structure-template)))))
+               ("disp" . org-export-dispatch)))))
 ```
 
 ### Customization options


### PR DESCRIPTION
Two examples in Basic Usage heading return an error, because they are called with wrong number of arguments.

I propose to change those slightly, in case of `org-insert-todo-heading` into `org-insert-todo-heading-respect-content` which doesn't require mandatory ARG.  In second case, since `org-insert-structure-template` also requires an argument one could define quick helper function along the lines of,

```emacs-lisp
(define my/org-insert-src-template ()
  (interactive)
  (org-insert-structure-template "src"))
```

but this would clash with later heading called Creating Commands.  One could also keep the original functions, but wrap them in lambdas (which is ugly for such a simple example).  Because of that I propose to use `org-export-dispatch` to highlight that the package doesn't have to be used just to insert some text quickly.

As a suggestion, it might be worth discussing whenever `call-interactively` would be a better option in `slash-commands-select-command`, if the Author wants to only use interactive commands.

## Summary by Sourcery

Fix wrong-number-of-arguments errors in README's Basic Usage examples by updating example commands to use functions that don't require mandatory arguments.

Documentation:
- Update 'todo' example to use `org-insert-todo-heading-respect-content` instead of `org-insert-todo-heading`.
- Replace 'src' example with `org-export-dispatch` under the "disp" key to avoid requiring an argument.